### PR TITLE
Added `useGetDimensions` hook

### DIFF
--- a/snippets/react/hook/use-get-dimensions.mdx
+++ b/snippets/react/hook/use-get-dimensions.mdx
@@ -1,0 +1,50 @@
+export const metadata = {
+  name: "useGetDimensions",
+  description: "A hook to get live dimensions of given container (ref of container)",
+  keywords: ["dimensions", "live", "hooks", "observer", "screen", "size"],
+  contributors: ["manjushsh"],
+};
+
+```tsx
+import { useState, useCallback } from "react";
+
+export function useGetDimensions() {
+  const [dimensions, setDimensions] = useState({ height: 0, width: 0 });
+
+  const ref = useCallback((node: HTMLElement | null) => {
+    if (node !== null) {
+      const resizeObserver = new ResizeObserver((entries) => {
+        if (!entries || entries.length === 0) return;
+
+        const entry = entries[0];
+        const { contentRect } = entry;
+
+        setDimensions({
+          height: contentRect.height,
+          width: contentRect.width,
+        });
+      });
+
+      resizeObserver.observe(node);
+
+      return () => {
+        resizeObserver.disconnect();
+      };
+    }
+  }, []);
+
+  return { dimensions, ref };
+};
+```
+
+```tsx
+const { dimensions, ref } = useGetDimensions();
+console.log("Dimensions: ", dimensions.width, dimensions.height)
+
+return (
+  <div ref={ref}>
+    <p>Hello There</p>
+    <textarea></textarea>
+  </div>
+);
+```

--- a/snippets/react/hook/use-get-dimensions.mdx
+++ b/snippets/react/hook/use-get-dimensions.mdx
@@ -12,29 +12,23 @@ export function useGetDimensions() {
   const [dimensions, setDimensions] = useState({ height: 0, width: 0 });
 
   const ref = useCallback((node: HTMLElement | null) => {
-    if (node !== null) {
-      const resizeObserver = new ResizeObserver((entries) => {
-        if (!entries || entries.length === 0) return;
+    if (!node) return;
 
-        const entry = entries[0];
-        const { contentRect } = entry;
-
-        setDimensions({
-          height: contentRect.height,
-          width: contentRect.width,
-        });
+    const resizeObserver = new ResizeObserver(([entry]) => {
+      const { contentRect } = entry;
+      setDimensions({
+        height: contentRect.height,
+        width: contentRect.width,
       });
+    });
 
-      resizeObserver.observe(node);
+    resizeObserver.observe(node);
 
-      return () => {
-        resizeObserver.disconnect();
-      };
-    }
+    return () => resizeObserver.disconnect();
   }, []);
 
   return { dimensions, ref };
-};
+}
 ```
 
 ```tsx


### PR DESCRIPTION
### What type of change does this PR introduce?

(Please check all that apply)

- [ ] 🐛 **Bug Fix**: Fixes a bug or issue.
- [ ] ✨ **New Feature**: Adds a new feature or functionality.
- [x] 📚 **Snippet Related**: Contributes a code snippet.
- [ ] ⚙️ **Other** (please describe):

### Summary of Changes

This MR adds `useGetDimensions` hook snippet which can be used for getting screen/element dimesions with help of`ResizeObserver` and `ref`

### Checklist

Before submitting your pull request, make sure you’ve done the following:

- [x] My code follows the project’s guidelines and formatting rules.
- [x] I’ve thoroughly tested my changes.
- [x] (for snippets) All folder and file names use the correct casing (e.g., lowercase for languages, kebab-case for categories/files).
- [x] (for snippets) My changes do not duplicate existing functionality or content.
- [x] I’ve provided a detailed summary of the changes and their purpose.