### PR TITLE
Add PAN card validation regex snippet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# webstorm files/folders
+.idea

--- a/snippets/javascript/string/pan-card-validate-regex.mdx
+++ b/snippets/javascript/string/pan-card-validate-regex.mdx
@@ -1,24 +1,24 @@
 export const metadata = {
-    name: "Validate PAN Number",
-    description: "Validate whether a given string is a valid Indian PAN card number.",
-    keywords: ["string", "regex", "pan", "validation", "india"],
-    contributors: ["PankajBaliyan"],
+  name: "Validate PAN Number",
+  description: "Validate whether a given string is a valid Indian PAN card number.",
+  keywords: ["string", "regex", "pan", "validation", "india"],
+  contributors: ["PankajBaliyan"],
 };
 
 ```javascript
 function validatePanNumber(pan) {
-    const panRegex = /^[A-Z]{5}[0-9]{4}[A-Z]{1}$/;
-    const upperPan = pan.toUpperCase(); // Normalize to uppercase
-    if (!panRegex.test(upperPan)) return false;
-    const validFirstChars = ['C', 'P', 'H', 'F', 'A', 'B', 'G', 'J', 'L', 'T'];
-    return validFirstChars.includes(upperPan[0]);
+  const panRegex = /^[A-Z]{5}[0-9]{4}[A-Z]{1}$/;
+  const upperPan = pan.toUpperCase(); // Normalize to uppercase
+  if (!panRegex.test(upperPan)) return false;
+  const validFirstChars = ["C", "P", "H", "F", "A", "B", "G", "J", "L", "T"];
+  return validFirstChars.includes(upperPan[0]);
 }
 ```
 
 ```javascript
-console.log(validatePanNumber("ABCDE1234Z")); // true
-console.log(validatePanNumber("PQRST1234Z")); // true
-console.log(validatePanNumber("XYZZZ1234A")); // false (invalid first char)
-console.log(validatePanNumber("ABCD12345Z")); // false (wrong pattern)
-console.log(validatePanNumber("abcde1234z")); // true (normalized to uppercase)
+validatePanNumber("ABCDE1234Z"); // true
+validatePanNumber("PQRST1234Z"); // true
+validatePanNumber("XYZZZ1234A"); // false (invalid first char)
+validatePanNumber("ABCD12345Z"); // false (wrong pattern)
+validatePanNumber("abcde1234z"); // true (normalized to uppercase)
 ```

--- a/snippets/javascript/string/pan-card-validate-regex.mdx
+++ b/snippets/javascript/string/pan-card-validate-regex.mdx
@@ -1,0 +1,24 @@
+export const metadata = {
+    name: "Validate PAN Number",
+    description: "Validate whether a given string is a valid Indian PAN card number.",
+    keywords: ["string", "regex", "pan", "validation", "india"],
+    contributors: ["PankajBaliyan"],
+};
+
+```javascript
+function validatePanNumber(pan) {
+    const panRegex = /^[A-Z]{5}[0-9]{4}[A-Z]{1}$/;
+    const upperPan = pan.toUpperCase(); // Normalize to uppercase
+    if (!panRegex.test(upperPan)) return false;
+    const validFirstChars = ['C', 'P', 'H', 'F', 'A', 'B', 'G', 'J', 'L', 'T'];
+    return validFirstChars.includes(upperPan[0]);
+}
+```
+
+```javascript
+console.log(validatePanNumber("ABCDE1234Z")); // true
+console.log(validatePanNumber("PQRST1234Z")); // true
+console.log(validatePanNumber("XYZZZ1234A")); // false (invalid first char)
+console.log(validatePanNumber("ABCD12345Z")); // false (wrong pattern)
+console.log(validatePanNumber("abcde1234z")); // true (normalized to uppercase)
+```


### PR DESCRIPTION
### What type of change does this PR introduce?

(Please check all that apply)

- [ ] 🐛 **Bug Fix**: Fixes a bug or issue.
- [ ] ✨ **New Feature**: Adds a new feature or functionality.
- [x] 📚 **Snippet Related**: Contributes a code snippet.
- [ ] ⚙️ **Other** (please describe):

### Summary of Changes

This pull request introduces a new JavaScript snippet that validates Indian PAN (Permanent Account Number) card numbers using a regular expression. It checks for the correct alphanumeric structure and validates the first character against a set of allowed entity codes (e.g., 'P' for individual, 'C' for company, etc.).

**Key Features:**
- Uses a regex pattern to match the standard PAN format: `^[A-Z]{5}[0-9]{4}[A-Z]{1}$`
- Converts input to uppercase for normalization
- Validates the first character against known valid types
- Includes console test cases for validation

### Checklist

- [x] My code follows the project’s guidelines and formatting rules  
- [x] I’ve thoroughly tested my changes  
- [x] Folder and file names use correct casing  
- [x] This snippet does not duplicate existing functionality  
- [x] Provided a clear description of changes and purpose  


### Additional Information

Contributor: **PankajBaliyan**  
Keywords: `string`, `regex`, `pan`, `validation`, `india`  

Example usage is included in the snippet for quick testing.
