### PR TITLE
Add `getLinkExtension` utility to extract file extensions from URLs i…

### DIFF
--- a/snippets/javascript/string/get-link-extension.mdx
+++ b/snippets/javascript/string/get-link-extension.mdx
@@ -1,0 +1,28 @@
+export const metadata = {
+  name: "Get Link Extension",
+  description: "Extracts the file extension from a given URL, if present.",
+  keywords: ["url", "file", "extension", "extract", "path", "link"],
+  contributors: ["PankajBaliyan"],
+};
+
+```javascript
+function getLinkExtension(url) {
+  try {
+    const path = new URL(url).pathname;
+    const lastSegment = path.split("/").pop();
+    return lastSegment.includes(".")
+      ? lastSegment.split(".").pop().toLowerCase()
+      : null;
+  } catch {
+    return null;
+  }
+}
+```
+
+```javascript
+getLinkExtension("https://example.com/file.pdf"); // ✅ "pdf"
+getLinkExtension("https://example.com/archive.tar.gz"); // ✅ "gz" — (Note: only the last extension is returned)
+getLinkExtension("https://example.com/video.mp4?download=true"); // ✅ "mp4"
+getLinkExtension("https://example.com/folder/"); // ❌ null (no file in the URL)
+getLinkExtension("invalid-url"); // ❌ null (invalid URL)
+```

--- a/snippets/javascript/string/get-link-extension.mdx
+++ b/snippets/javascript/string/get-link-extension.mdx
@@ -20,9 +20,9 @@ function getLinkExtension(url) {
 ```
 
 ```javascript
-getLinkExtension("https://example.com/file.pdf"); // ✅ "pdf"
-getLinkExtension("https://example.com/archive.tar.gz"); // ✅ "gz" — (Note: only the last extension is returned)
-getLinkExtension("https://example.com/video.mp4?download=true"); // ✅ "mp4"
-getLinkExtension("https://example.com/folder/"); // ❌ null (no file in the URL)
-getLinkExtension("invalid-url"); // ❌ null (invalid URL)
+getLinkExtension("https://example.com/file.pdf"); // "pdf"
+getLinkExtension("https://example.com/archive.tar.gz"); // "gz"(note how only the last extension is returned)
+getLinkExtension("https://example.com/video.mp4?download=true"); // "mp4"
+getLinkExtension("https://example.com/folder/"); // null (no file in the URL)
+getLinkExtension("invalid-url"); // null (invalid URL)
 ```


### PR DESCRIPTION
## ✅ What type of change does this PR introduce?

(Please check all that apply)

- [ ] 🐛 Bug Fix: Fixes a bug or issue.  
- [x] ✨ New Feature: Adds a new feature or functionality.  
- [x] 📚 Snippet Related: Contributes a code snippet.  
- [ ] ⚙️ Other (please describe):

---

## 📝 Summary of Changes

This pull request introduces a new JavaScript snippet that extracts the file extension from a given URL. It uses the native `URL` object to parse the input and retrieves the last segment of the path to isolate and return the file extension. If no extension is present or the URL is invalid, it returns `null`.

---

## 🚀 Key Features

- Parses the input using the `URL` constructor to ensure robustness  
- Extracts the final path segment to find the file name  
- Handles complex URLs including query strings (e.g., `?download=true`)  
- Returns only the **last** extension (e.g., `.gz` from `.tar.gz`)  
- Returns `null` for invalid URLs or non-file paths  
- Includes console test cases for easy validation

---

## ✅ Checklist

- [x] My code follows the project’s guidelines and formatting rules  
- [x] I’ve thoroughly tested my changes  
- [x] Folder and file names use correct casing  
- [x] This snippet does not duplicate existing functionality  
- [x] Provided a clear description of changes and purpose  

---

## 📎 Additional Information

- **Contributor**: PankajBaliyan  
- **Keywords**: url, file, extension, extract, path, link  

Example usage is included in the snippet for quick testing.