### PR TITLE
feat(docs): add validate-gstin.mdx for GSTIN validation utility

### DIFF
--- a/lib/languages.ts
+++ b/lib/languages.ts
@@ -90,5 +90,5 @@ export const LANGUAGE_EXTENSIONS: Map<string, string> = new Map([
   ["rust", "rs"],
   ["gdscript", "gd"],
   ["regex", "txt"], // regex is not a language, but txt is
-  ["nix", "nix"]
+  ["nix", "nix"],
 ]);

--- a/snippets/javascript/string/validate-gstin.mdx
+++ b/snippets/javascript/string/validate-gstin.mdx
@@ -1,8 +1,8 @@
 export const metadata = {
-    name: "Validate GSTIN",
-    description: "Validates a given Indian GSTIN (Goods and Services Tax Identification Number) based on format, state code, and embedded PAN.",
-    keywords: ["GSTIN", "validate", "India", "regex", "PAN", "state code", "tax"],
-    contributors: ["PankajBaliyan"],
+  name: "Validate GSTIN",
+  description: "Validates a given Indian GSTIN (Goods and Services Tax Identification Number) based on format, state code, and embedded PAN.",
+  keywords: ["GSTIN", "validate", "India", "regex", "PAN", "state code", "tax"],
+  contributors: ["PankajBaliyan"],
 };
 
 ```javascript

--- a/snippets/javascript/string/validate-gstin.mdx
+++ b/snippets/javascript/string/validate-gstin.mdx
@@ -1,0 +1,48 @@
+export const metadata = {
+    name: "Validate GSTIN",
+    description: "Validates a given Indian GSTIN (Goods and Services Tax Identification Number) based on format, state code, and embedded PAN.",
+    keywords: ["GSTIN", "validate", "India", "regex", "PAN", "state code", "tax"],
+    contributors: ["PankajBaliyan"],
+};
+
+```javascript
+function validateGSTIN(gstin) {
+  // Regex for GSTIN: 2 digits, 5 letters, 4 digits, 1 letter, 1 digit, 1 letter, 1 alphanumeric
+  const gstinRegex = /^[0-3][0-9][A-Z]{5}[0-9]{4}[A-Z]{1}[1-9A-Z]{1}Z[0-9A-Z]{1}$/;
+
+  if (!gstinRegex.test(gstin)) return false;
+
+  const validStateCodes = [
+    "01", "02", "03", "04", "05", "06", "07", "08", "09", "10",
+    "11", "12", "13", "14", "15", "16", "17", "18", "19", "20",
+    "21", "22", "23", "24", "25", "26", "27", "28", "29", "30",
+    "31", "32", "33", "34", "35", "36", "37"
+  ];
+  const stateCode = gstin.slice(0, 2);
+  if (!validStateCodes.includes(stateCode)) return false;
+
+  const pan = gstin.slice(2, 12);
+  const panRegex = /^[A-Z]{5}[0-9]{4}[A-Z]{1}$/;
+  const validFirstChars = ['C', 'P', 'H', 'F', 'A', 'B', 'G', 'J', 'L', 'T'];
+  if (!panRegex.test(pan) || !validFirstChars.includes(pan[0])) return false;
+
+  if (gstin[13] !== 'Z') return false;
+
+  return true;
+}
+```
+
+```javascript
+// Valid GSTINs
+validateGSTIN("29ABCDE1234F1Z5"); // true
+validateGSTIN("27AABCU1234F1Z6"); // true
+validateGSTIN("10AABCD1234F1Z7"); // true
+validateGSTIN("19AABCE1234F1Z8"); // true
+
+// Invalid GSTINs
+validateGSTIN("29ABCDE1234F1Z"); // false - missing last character
+validateGSTIN("12345ABCDE123F1Z"); // false - invalid state code and format
+validateGSTIN("ABCD1234F1Z5"); // false - too short
+validateGSTIN("29ABCDE1234F1Z5Z"); // false - extra character
+validateGSTIN("12ABCD12345F1Z5"); // false - invalid PAN format
+```


### PR DESCRIPTION
- Added a new .mdx documentation file: `validate-gstin.mdx`  
- Includes metadata, function logic, and usage examples  
- Validates Indian GSTIN format with regex, state code, and PAN structure checks  

---

### What type of change does this PR introduce?

- [ ] 🐛 **Bug Fix**: Fixes a bug or issue.  
- [ ] ✨ **New Feature**: Adds a new feature or functionality.  
- [x] 📚 **Snippet Related**: Contributes a code snippet.  
- [ ] ⚙️ **Other** (please describe):

---

### Summary of Changes

This pull request adds a new `.mdx` documentation file, `validate-gstin.mdx`, which includes a reusable JavaScript function to validate Indian GSTINs. The snippet uses a detailed regular expression to check the structure of the GSTIN and validates against known state codes and PAN formats. The file includes usage examples for both valid and invalid inputs and follows the standard format used across the project.

---

### Checklist

Before submitting your pull request, make sure you’ve done the following:

- [x] My code follows the project’s guidelines and formatting rules.  
- [x] I’ve thoroughly tested my changes.  
- [x] (for snippets) All folder and file names use the correct casing (e.g., lowercase for languages, kebab-case for categories/files).  
- [x] (for snippets) My changes do not duplicate existing functionality or content.  
- [x] I’ve provided a detailed summary of the changes and their purpose.  

---

### Additional Information

This snippet is useful for applications involving tax compliance, form validation, and Indian business logic. It can be extended in the future to support checksum-based validation when required.